### PR TITLE
Fix an index-out-of-range panic in GSSAPI client

### DIFF
--- a/client/authn/negotiate_gssapi.go
+++ b/client/authn/negotiate_gssapi.go
@@ -55,7 +55,7 @@ func (n *negotiate) AuthRespond(challenge string, req *http.Request) (result boo
 		if serverhost == "" {
 			serverhost = req.URL.Host
 		}
-		if serverhost[0] == os.PathSeparator {
+		if len(serverhost) == 0 || serverhost[0] == os.PathSeparator {
 			serverhost, _ = os.Hostname()
 		}
 		sep := strings.LastIndex(serverhost, ":")


### PR DESCRIPTION
When trying to establish the server's hostname for use when constructing a GSSAPI service name, don't try to read the first byte of the hostname without ensuring that it has a first byte, first.  I came across this during testing.
