### PR TITLE
Fix locating authentication schemes

### DIFF
--- a/client/authn/middleware.go
+++ b/client/authn/middleware.go
@@ -26,7 +26,7 @@ func NewAuthResponderMiddleware(logger logger.Logger, auth ...AuthResponder) mid
 	responders := make(map[string]AuthResponder)
 	for _, a := range auth {
 		a.SetLogger(logger)
-		responders[a.Scheme()] = a
+		responders[strings.ToLower(a.Scheme())] = a
 	}
 
 	return func(next transport.Sender) transport.Sender {


### PR DESCRIPTION
Authentication scheme names are case-insensitive tokens, and while we were lower-casing names supplied by the HTTP server to derive a key for a map, we weren't also doing that while populating the map.
